### PR TITLE
Use Next.js compiler instead of Babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-    "presets": ["next/babel"],
-    "plugins": ["styled-components"]
-}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
         "@types/node": "17.0.22",
         "@types/react": "17.0.41",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
-        "babel-plugin-styled-components": "^2.0.7",
         "eslint": "8.11.0",
         "eslint-config-next": "12.1.0",
         "eslint-config-prettier": "^8.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,17 +810,6 @@ axobject-query@^2.2.0:
     lodash "^4.17.11"
     picomatch "^2.3.0"
 
-babel-plugin-styled-components@^2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz#c81ef34b713f9da2b7d3f5550df0d1e19e798086"
-  integrity sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.16.0"
-    "@babel/helper-module-imports" "^7.16.0"
-    babel-plugin-syntax-jsx "^6.18.0"
-    lodash "^4.17.11"
-    picomatch "^2.3.0"
-
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"


### PR DESCRIPTION
- Babel の代わりに Next.js コンパイラ (SWC) を使用するように修正
  - Next.js コンパイラは Babel コンフィグが無い状態にすると自動で有効になる
  - ref: https://nextjs.org/docs/advanced-features/compiler, https://swc.rs/
- SWC の利点として、Babel に比べて最大で約70倍コンパイル速度が上がるので使用可能な場合使った方が良い
  - 現在は styled-components のコンパイルもサポートされているので問題ない（はず）
